### PR TITLE
Enhance documentation and minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jl.mem
 .DS_Store
 Manifest.toml
+docs/build

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlmDCA"
 uuid = "06784e46-84fc-5582-b8de-0e984192b79e"
 author = ["Andrea Pagnani <andrea.pagnani@gmail.com>"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 DCAUtils = "e41cd558-3099-4f6e-a65d-5336857e40aa"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 PlmDCA = "06784e46-84fc-5582-b8de-0e984192b79e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,16 +18,16 @@ Protein families are given in form of multiple sequence alignments (MSA) $D =
 (a^m_i |i = 1,\dots,L;\,m = 1,\dots,M)$ of $M$ proteins of aligned length $L$.
 The entries $a^m_i$ equal either one of the standard 20 amino acids, or the
 alignment gap $–$. In total, we have $q = 21$ possible different symbols in D.
-The aim of unsupervised generative modeling is to earn a statistical model
+The aim of unsupervised generative modeling is to learn a statistical model
 $P(a_1,\dots,a_L)$ of (aligned) full-length sequences, which faithfully reflects
 the variability found in $D$: sequences belonging to the protein family of
 interest should have comparably high probabilities, unrelated sequences very
 small probabilities. Here we propose a computationally efficient approach based
-on pseudo-likelihood maximization. 
+on pseudo-likelihood maximization.
 
 We start from the exact decomposition $P_i(a_i| a_{\setminus i})$ where
 $a_{\setminus i} := \{a_1,\dots,a_{i-1},a_{i+1},\dots,a_i\}$, i.e. all residues of the sequence
-of amino acids but the one relative to residue $i$. 
+of amino acids but the one relative to residue $i$.
 
 Here, we use the following parametrization:
 
@@ -53,7 +53,7 @@ The typical pipeline to use the package is:
 
 * Compute PlmDCA parameters from a multiple sequence alignment:
 
-``` 
+```
 julia> res=plmdca(filefasta; kwds...)
 ```
 
@@ -67,21 +67,21 @@ $ julia -t nthreads # put here nthreads equal to the number of cores you want to
 
 If you want to set permanently the number of threads to the desired value, you can either create a default environment variable `export JULIA_NUM_THREADS=24` in your `.bashrc`. More information [here](https://docs.julialang.org/en/v1.6/manual/multi-threading/)
 
-## Load PlmDCA package 
+## Load PlmDCA package
 
 The package is on the General Registry. It can be installed from the package
 manager by
 ```
 pkg> add PlmDCA
 ```
-and 
+and
 ```
 julia> using PlmDCA
 ```
 
 ## Learn the parameters
 
-There are two different learning strategies: 
+There are two different learning strategies:
 
 * The asymmetric one invoked by the `plmdca_asym` method (the `plmdca` method
   points to the asymmetric strategy)
@@ -93,19 +93,24 @@ Both methods return the parameters  `res::PlmOut`, a `struct` containing:
 1. `Jtensor`: the 4 dimensional Array (q×q×L×L)  of the couplings in zero-sum gauge J[a,b,i,j]
 2. `Htensor`: the 2 dimensional Array (q×L) of the fields in zero-sum gauge h[a,i]
 3. `pslike`: a vector of length `L` containing the log-pseudolikelihoods
-4. `score`: a vector of ``(i,j,val)::Tuple{Int,Int,Float64}` containing the DCA
+4. `score`: a vector of `(i,j,val)::Tuple{Int,Int,Float64}` containing the DCA
    score `val` relative to the `i,j` pair in descending order.
 
-For both methods, the keyword arguments (with their default value) are:
+For both methods, the algorithmic keyword arguments (with their default value) are:
 
 * `epsconv::Real=1.0e-5` (convergence parameter)
 * `maxit::Int=1000` (maximum number of iteration - don't change)
 * `verbose::Bool=true` (set to `false` to suppress printing on screen)
 * `method::Symbol=:LD_LBFGS` (optimization method)
 
+Example:
+
 ```
 res=plmdca("data/PF14/PF00014_mgap6.fasta.gz", verbose=false, lambdaJ=0.02,lambdaH=0.001);
 ```
+
+Additional parameters include those of [`PlmDCA.read_fasta`](@ref), which
+determine the effective sequence diversity.
 
 ## Contact Prediction
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -47,8 +47,21 @@ function compute_APC(J::Array{Float64,4},N,q)
     return FN
 end
 
+"""
+    PlmDCA.read_fasta(filename; max_gap_fraction::Real, theta, remove_dups::Bool) -> W, Zint, N, M, q
 
-function read_fasta(filename::String,max_gap_fraction::Real, theta::Any, remove_dups::Bool)
+Reads a FASTA file and returns the per-sequence weights, integer representation
+of sequences, length of sequences, number of sequences, and the number of
+states.
+
+See
+[`DCAUtils.read_fasta_alignment`](https://carlobaldassi.github.io/DCAUtils.jl/stable/#DCAUtils.ReadFastaAlignment.read_fasta_alignment)
+about the integer representation of sequences and meaning of `max_gap_fraction`.
+If `remove_dups` is `true`, duplicate sequences are removed.
+
+`theta` controls the sequence-weighting computation, see [`DCAUtils.compute_weights`](https://carlobaldassi.github.io/DCAUtils.jl/stable/#DCAUtils.compute_weights).
+"""
+function read_fasta(filename::String,max_gap_fraction::Real, theta, remove_dups::Bool)
 
     Z = read_fasta_alignment(filename, max_gap_fraction)
     if remove_dups
@@ -75,7 +88,7 @@ function compute_ranking(S::Matrix{Float64}, min_separation::Int = 5)
     end
 
     sort!(R, by=x->x[3], rev=true)
-    return R 
+    return R
 end
 
 function sumexp(vec::Array{Float64,1})


### PR DESCRIPTION
- Add docs for `read_fasta` (explaining `theta` etc)
- Eliminate duplication of docstrings
- Fix typos
- Modernize type names (`Array{T,2}` -> `Matrix{T}`)
- Remove unused kwargs
- Specify [compat] on Documenter